### PR TITLE
Fix import order for training script

### DIFF
--- a/src/finetune_phi4_nl2sql.py
+++ b/src/finetune_phi4_nl2sql.py
@@ -1,8 +1,9 @@
 # Fine-tune Microsoft Phi-4 Mini-Instruct (3.8 B) for NL→SQL with Unsloth QLoRA
 # Hardware target: 1× NVIDIA L4 (24 GB VRAM)
 
-import torch, os, warnings
+import torch
 from unsloth import FastLanguageModel, SFTTrainer
+from unsloth.chat_templates import get_chat_template
 from datasets import load_dataset
 from transformers import TrainingArguments
 
@@ -22,7 +23,7 @@ model, tokenizer = FastLanguageModel.from_pretrained(
     device_map           = "auto",
 )
 
-from unsloth.chat_templates import get_chat_template
+
 tokenizer = get_chat_template(tokenizer, chat_template="phi-4")
 
 # ----------------------------- #


### PR DESCRIPTION
## Summary
- fix duplicate import in `finetune_phi4_nl2sql.py`
- ensure `get_chat_template` is imported at the top of the file

## Testing
- `ruff check src/finetune_phi4_nl2sql.py`

------
https://chatgpt.com/codex/tasks/task_e_684038aae4dc8333a3414d9bb6ab15e7