### PR TITLE
Release v1.0.0 and tighten GPU checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## What's New in v1.0.0
+
+- First stable release on PyPI.
+- `bitsandbytes` is now a core dependency; install CUDA-enabled PyTorch separately.
+- The CLI detects unsupported environments and advises installing PyTorch with CUDA or switching to a GPU-equipped machine.
+
 ## Added
 
 - **Cross-Dialect SQL Post-Processing**

--- a/README.md
+++ b/README.md
@@ -100,24 +100,19 @@ Transqlate currently supports Python 3.8 through 3.13.
 
 ### **Installation (via PyPI)**
 
-**Important:**  
-Transqlate-Phi4 will NOT work on non-GPU/CPU-only devices. The model weights are 4-bit quantized and require a CUDA-capable GPU and a working `bitsandbytes` installation for inference. Due to this, only the following installation methods are supported:
+**Important:**
+The fine-tuned model is uploaded in 4‑bit format and currently **requires a CUDA-capable GPU**. CPU-only execution is not supported.
+
+1. Install PyTorch with your CUDA version from [pytorch.org](https://pytorch.org/get-started/locally/).
+2. Then install Transqlate from PyPI:
 
 ```bash
-pip install "transqlate[cuda118]"  # CUDA 11.8
-pip install "transqlate[cuda126]"  # CUDA 12.6
-pip install "transqlate[cuda128]"  # CUDA 12.8
+pip install transqlate
 ```
 
-**Note:**  
-The following installation will NOT work and is intentionally omitted:
-<!-- pip install transqlate -->
+`bitsandbytes` is installed automatically as a dependency and will load the model in 4‑bit mode when a compatible GPU is available.
 
-#### GPU extras (bitsandbytes)
-
-To load the model in 4‑bit quantised mode, install Transqlate with the extra that matches your CUDA version. This pulls in the correct PyTorch and `bitsandbytes` builds.
-
-CPU-only users or those on an unsupported Python version cannot run `transqlate` due to the quantised model weights.
+If you do not have a GPU, this tool cannot be used at the moment.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "transqlate"
-version = "0.1.9"
+version = "1.0.0"
 description = "Natural Language to SQL CLI powered by a fine-tuned LLM."
 authors = [
     { name="Shaurya Sethi", email="shauryaswapansethi@gmail.com" }
@@ -26,28 +26,9 @@ dependencies = [
     "rich==14.0.0",
     "sentence_transformers==4.1.0",
     "transformers==4.51.3",
-    "torch==2.7.0", 
     "accelerate==1.7.0",
+    "bitsandbytes==0.46.0",
     "huggingface_hub==0.31.2"
-]
-
-[project.optional-dependencies]
-# For CUDA 11.8 users:
-cuda118 = [
-    "torch==2.7.0+cu118 ; platform_system=='Linux' and platform_machine=='x86_64'",
-    "bitsandbytes==0.46.0",
-]
-
-# For CUDA 12.6 users:
-cuda126 = [
-    "torch==2.7.0+cu126 ; platform_system=='Linux' and platform_machine=='x86_64'",
-    "bitsandbytes==0.46.0",
-]
-
-# For CUDA 12.8 users:
-cuda128 = [
-    "torch==2.7.0+cu128 ; platform_system=='Linux' and platform_machine=='x86_64'",
-    "bitsandbytes==0.46.0",
 ]
 
 [project.scripts]

--- a/src/transqlate/inference.py
+++ b/src/transqlate/inference.py
@@ -129,8 +129,12 @@ class NL2SQLInference:
                     **model_kwargs,
                 )
         except RuntimeError as e:
-            if use_4bit and "bitsandbytes" in str(e).lower():
+            if "bitsandbytes" in str(e).lower():
                 model_kwargs.pop("quantization_config", None)
+                if hasattr(config, "quantization_config"):
+                    delattr(config, "quantization_config")
+                    config = config.__class__.from_dict(config.to_dict())
+                    model_kwargs["config"] = config
                 with warnings.catch_warnings():
                     warnings.filterwarnings(
                         "ignore",


### PR DESCRIPTION
## Summary
- release Transqlate 1.0.0
- move bitsandbytes to main deps and drop optional CUDA extras
- improve CLI handling when no compatible GPU is available
- retry model load on bitsandbytes errors even without 4-bit mode
- document installation changes
- add regression test for CPU runtime error

## Testing
- `pip install pandas==2.2.3`
- `pip install pytest-mock`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852c15721948333aa3d5cbcdc256185