### PR TITLE
Enhance run_inference.py robustness

### DIFF
--- a/benchmark/scripts/run_inference.py
+++ b/benchmark/scripts/run_inference.py
@@ -4,8 +4,12 @@
 # Dependencies: json, pathlib, logging, torch, tqdm, transformers, sentence-transformers,
 # and local transqlate modules.
 
+import argparse
 import json
 import logging
+import signal
+import sys
+import time
 from pathlib import Path
 
 import torch
@@ -19,7 +23,62 @@ from transqlate.embedding_utils import load_sentence_embedder
 
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO, format="%(levelname)s | %(message)s")
+LOG_FORMAT = "%(asctime)s | %(levelname)s | %(message)s"
+logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
+
+
+def parse_args(argv=None) -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Run Transqlate inference on the SPIDER test set."
+    )
+    parser.add_argument(
+        "--start-index",
+        type=int,
+        default=None,
+        help="Index of the first example to process",
+    )
+    parser.add_argument(
+        "--end-index",
+        type=int,
+        default=None,
+        help="Index after the last example to process",
+    )
+    parser.add_argument(
+        "--checkpoint",
+        type=Path,
+        default=None,
+        help="Path to checkpoint file",
+    )
+    parser.add_argument(
+        "--checkpoint-interval",
+        type=int,
+        default=10,
+        help="Save checkpoint every N examples",
+    )
+    return parser.parse_args(argv)
+
+
+def save_checkpoint(path: Path, predictions: list, index: int) -> None:
+    """Write checkpoint data to ``path``."""
+    try:
+        data = {"index": index, "predictions": predictions}
+        path.write_text(json.dumps(data))
+        logger.info("Checkpoint saved at index %s to %s", index, path)
+    except Exception as exc:  # pragma: no cover - runtime safeguard
+        logger.error("Failed to save checkpoint: %s", exc)
+
+
+def load_checkpoint(path: Path) -> tuple[list, int]:
+    """Return predictions and next index from ``path``."""
+    try:
+        data = json.loads(path.read_text())
+        predictions = data.get("predictions", [])
+        index = int(data.get("index", len(predictions)))
+        return predictions, index
+    except Exception as exc:  # pragma: no cover - runtime safeguard
+        logger.error("Failed to load checkpoint %s: %s", path, exc)
+        return [], 0
 
 
 def transform_schema(spider_schema: dict) -> dict:
@@ -91,7 +150,9 @@ def extract_schema_token_span(prompt_text: str, tokenizer):
     return schema_tokens
 
 
-def main() -> None:
+def main(argv=None) -> None:
+    """Entry point for the benchmark script."""
+    args = parse_args(argv)
     base_dir = Path(__file__).resolve().parents[1]
     data_dir = base_dir / "data"
     results_dir = base_dir / "results"
@@ -104,40 +165,93 @@ def main() -> None:
     table_entries = json.loads(tables_path.read_text())
     schemas = {entry["db_id"]: transform_schema(entry) for entry in table_entries}
 
+    cp_path = args.checkpoint or results_dir / "predictions_checkpoint.json"
+    predictions: list[str] = []
+    start_index = 0
+    if cp_path.exists():
+        predictions, start_index = load_checkpoint(cp_path)
+
+    if args.start_index is not None:
+        start_index = args.start_index
+
+    end_index = args.end_index if args.end_index is not None else len(examples)
+    predictions = predictions[:start_index]
+    failed: list[int] = []
+
     inference = NL2SQLInference()
     embed_model = load_sentence_embedder("all-MiniLM-L6-v2")
-    orchestrators = {}
-    predictions = []
+    orchestrators: dict[str, SchemaRAGOrchestrator] = {}
 
-    for ex in tqdm(examples, desc="Infer", unit="ex"):
-        question = ex.get("question", "")
-        db_id = ex.get("db_id")
-        schema = schemas.get(db_id)
-        if schema is None:
-            logger.error("Schema for db_id %s not found", db_id)
-            predictions.append("")
-            continue
-        orchestrator = orchestrators.get(db_id)
-        if orchestrator is None:
-            orchestrator = SchemaRAGOrchestrator(
-                inference.tokenizer, schema, embed_model=embed_model
-            )
-            orchestrators[db_id] = orchestrator
-        prompt_text, _, _ = orchestrator.build_prompt(question)
-        try:
-            schema_tokens = extract_schema_token_span(prompt_text, inference.tokenizer)
-        except Exception as exc:  # pragma: no cover - runtime safeguard
-            logger.error("Failed to locate schema tokens for %s: %s", db_id, exc)
-            predictions.append("")
-            continue
-        _, sql_text = inference.generate(question, schema_tokens)
-        predictions.append(sql_text.strip())
+    current_index = start_index
+
+    def handle_signal(signum, frame):  # noqa: D401 - callback signature
+        del frame
+        logger.warning("Received signal %s; saving checkpoint", signum)
+        save_checkpoint(cp_path, predictions, current_index)
+        sys.exit(0)
+
+    signal.signal(signal.SIGINT, handle_signal)
+    signal.signal(signal.SIGTERM, handle_signal)
+
+    start_time = time.time()
+    with tqdm(
+        range(start_index, end_index),
+        desc="Infer",
+        unit="ex",
+        initial=start_index,
+        total=end_index,
+    ) as progress:
+        for idx in progress:
+            current_index = idx
+            ex = examples[idx]
+            question = ex.get("question", "")
+            db_id = ex.get("db_id")
+            try:
+                schema = schemas[db_id]
+                orchestrator = orchestrators.get(db_id)
+                if orchestrator is None:
+                    orchestrator = SchemaRAGOrchestrator(
+                        inference.tokenizer, schema, embed_model=embed_model
+                    )
+                    orchestrators[db_id] = orchestrator
+                prompt_text, _, _ = orchestrator.build_prompt(question)
+                schema_tokens = extract_schema_token_span(
+                    prompt_text, inference.tokenizer
+                )
+                _, sql_text = inference.generate(question, schema_tokens)
+                predictions.append(sql_text.strip())
+            except Exception as exc:  # pragma: no cover - runtime safeguard
+                logger.exception(
+                    "Failed example %s (db_id=%s): %s", idx, db_id, exc
+                )
+                predictions.append("")
+                failed.append(idx)
+            if (idx + 1 - start_index) % args.checkpoint_interval == 0:
+                save_checkpoint(cp_path, predictions, idx + 1)
+
+    elapsed = time.time() - start_time
+    save_checkpoint(cp_path, predictions, end_index)
 
     results_dir.mkdir(parents=True, exist_ok=True)
     out_path = results_dir / "predictions.sql"
     with out_path.open("w", encoding="utf-8") as fh:
         for line in predictions:
             fh.write(line + "\n")
+
+    if failed:
+        fail_path = results_dir / "failed_examples.txt"
+        fail_path.write_text("\n".join(str(i) for i in failed))
+        logger.info("Failed indices written to %s", fail_path)
+
+    processed = end_index - start_index
+    speed = processed / elapsed if elapsed else 0.0
+    logger.info(
+        "Processed %s examples with %s failures in %.1fs (%.2f ex/s)",
+        processed,
+        len(failed),
+        elapsed,
+        speed,
+    )
     logger.info("Predictions written to %s", out_path)
 
 

--- a/tests/test_run_inference.py
+++ b/tests/test_run_inference.py
@@ -39,10 +39,24 @@ def test_embedder_loaded_once(monkeypatch, setup_data):
     st_mod.SentenceTransformer = object
     sys.modules.setdefault("sentence_transformers", st_mod)
     tqdm_mod = types.ModuleType("tqdm")
-    tqdm_mod.tqdm = lambda *a, **k: a[0] if a else []
+    class DummyTqdm:
+        def __init__(self, iterable=None, *a, **k):
+            self.iterable = iterable or []
+
+        def __iter__(self):
+            return iter(self.iterable)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    tqdm_mod.tqdm = DummyTqdm
     sys.modules.setdefault("tqdm", tqdm_mod)
     # stub transqlate modules to avoid heavy imports during load
     transqlate_mod = types.ModuleType("transqlate")
+    transqlate_mod.__path__ = []
     sys.modules.setdefault("transqlate", transqlate_mod)
     inf_mod = types.ModuleType("transqlate.inference")
     inf_mod.NL2SQLInference = object
@@ -54,7 +68,7 @@ def test_embedder_loaded_once(monkeypatch, setup_data):
     sys.modules.setdefault("transqlate.schema_pipeline.orchestrator", orch_mod)
     emb_mod = types.ModuleType("transqlate.embedding_utils")
     emb_mod.load_sentence_embedder = lambda *a, **k: None
-    sys.modules.setdefault("transqlate.embedding_utils", emb_mod)
+    sys.modules["transqlate.embedding_utils"] = emb_mod
     spec = importlib.util.spec_from_file_location(
         "run_inference",
         Path(__file__).resolve().parents[1]
@@ -96,7 +110,85 @@ def test_embedder_loaded_once(monkeypatch, setup_data):
     monkeypatch.setattr(run_inference, "extract_schema_token_span", lambda *a, **k: [])
     monkeypatch.setattr(run_inference, "transform_schema", lambda e: {})
 
-    run_inference.main()
+    run_inference.main([])
 
     assert counts["embed"] == 1
     assert counts["orch"] == 1
+
+
+def test_resume_from_checkpoint(monkeypatch, setup_data, tmp_path):
+    bench_dir, scripts_dir = setup_data
+    import importlib.util
+    import sys
+    import types
+
+    sys.modules.setdefault("torch", types.ModuleType("torch"))
+    tfm_mod = types.ModuleType("transformers")
+    tfm_mod.AutoTokenizer = object
+    sys.modules.setdefault("transformers", tfm_mod)
+    st_mod = types.ModuleType("sentence_transformers")
+    st_mod.SentenceTransformer = object
+    sys.modules.setdefault("sentence_transformers", st_mod)
+    tqdm_mod = types.ModuleType("tqdm")
+    class DummyTqdm:
+        def __init__(self, iterable=None, *a, **k):
+            self.iterable = iterable or []
+
+        def __iter__(self):
+            return iter(self.iterable)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    tqdm_mod.tqdm = DummyTqdm
+    sys.modules.setdefault("tqdm", tqdm_mod)
+    transqlate_mod = types.ModuleType("transqlate")
+    transqlate_mod.__path__ = []
+    sys.modules.setdefault("transqlate", transqlate_mod)
+    inf_mod = types.ModuleType("transqlate.inference")
+    inf_mod.NL2SQLInference = object
+    sys.modules.setdefault("transqlate.inference", inf_mod)
+    schema_pkg = types.ModuleType("transqlate.schema_pipeline")
+    sys.modules.setdefault("transqlate.schema_pipeline", schema_pkg)
+    orch_mod = types.ModuleType("transqlate.schema_pipeline.orchestrator")
+    orch_mod.SchemaRAGOrchestrator = object
+    sys.modules.setdefault("transqlate.schema_pipeline.orchestrator", orch_mod)
+    emb_mod = types.ModuleType("transqlate.embedding_utils")
+    emb_mod.load_sentence_embedder = lambda *a, **k: None
+    sys.modules["transqlate.embedding_utils"] = emb_mod
+
+    spec = importlib.util.spec_from_file_location(
+        "run_inference",
+        Path(__file__).resolve().parents[1]
+        / "benchmark"
+        / "scripts"
+        / "run_inference.py",
+    )
+    run_inference = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(run_inference)  # type: ignore
+
+    monkeypatch.setattr(run_inference, "__file__", str(scripts_dir / "run_inference.py"))
+
+    class DummyInf:
+        def __init__(self):
+            self.tokenizer = object()
+
+        def generate(self, question, tokens):
+            return None, question + "_sql"
+
+    monkeypatch.setattr(run_inference, "NL2SQLInference", DummyInf)
+    monkeypatch.setattr(run_inference, "SchemaRAGOrchestrator", lambda *a, **k: types.SimpleNamespace(build_prompt=lambda q: ("prompt", [], {})))
+    monkeypatch.setattr(run_inference, "extract_schema_token_span", lambda *a, **k: [])
+    monkeypatch.setattr(run_inference, "transform_schema", lambda e: {})
+
+    ckpt_path = tmp_path / "ckpt.json"
+    ckpt_path.write_text(json.dumps({"index": 1, "predictions": ["old"]}))
+
+    run_inference.main(["--checkpoint", str(ckpt_path), "--end-index", "2"])
+
+    data = json.loads(ckpt_path.read_text())
+    assert data["index"] == 2
+    assert len(data["predictions"]) == 2


### PR DESCRIPTION
## Summary
- add CLI options and checkpoint helpers
- implement checkpointing, progress bar, and error handling in benchmark inference script
- update tests for new main() interface and add resume checkpoint test

## Testing
- `pytest -q`
